### PR TITLE
Improve Sentry usage

### DIFF
--- a/lib/feature/settings/bloc/system_configuration_cubit.dart
+++ b/lib/feature/settings/bloc/system_configuration_cubit.dart
@@ -22,8 +22,8 @@ class SystemConfigurationCubit extends Cubit<SystemConfigurationState> {
       final configuration = await _repository.getConfiguration();
       emit(SystemConfigurationStateSettingsFetched(
           currentConfiguration: configuration));
-    } catch (exception) {
-      Sentry.captureException(exception);
+    } catch (exception, stackTrace) {
+      Sentry.captureException(exception, stackTrace: stackTrace);
       emit(SystemConfigurationStateSettingsFetchingError());
     }
   }
@@ -160,8 +160,8 @@ class SystemConfigurationCubit extends Cubit<SystemConfigurationState> {
             isOfflineModeTelemetryEnabledFlag ? 1 : 0);
         await _repository.setOfflineModeTeslaFirmwareDownloads(
             isOfflineModeTeslaFirmwareDownloadsEnabledFlag ? 1 : 0);
-      } catch (exception) {
-        Sentry.captureException(exception);
+      } catch (exception, stackTrace) {
+        Sentry.captureException(exception, stackTrace: stackTrace);
         emit(SystemConfigurationStateSettingsSavingFailedError());
       }
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:tesla_android/common/di/ta_locator.dart';
 import 'package:tesla_android/common/navigation/ta_page_factory.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await configureTADependencies();
-
+Future<void> main() async {
   await SentryFlutter.init(
     (options) {
       options.dsn =
@@ -14,11 +11,18 @@ void main() async {
       options.attachScreenshot = true;
       options.attachViewHierarchy = true;
     },
-    appRunner: () => runApp(
-      SentryScreenshotWidget(
-        child: SentryUserInteractionWidget(
-          child: TeslaAndroid(),
-        ),
+    appRunner: _runMyApp,
+  );
+}
+
+Future<void> _runMyApp() async {
+  // Sentry already initialized WidgetsFlutterBinding.ensureInitialized();
+  await configureTADependencies();
+
+  runApp(
+    SentryScreenshotWidget(
+      child: SentryUserInteractionWidget(
+        child: TeslaAndroid(),
       ),
     ),
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,9 @@ void main() async {
     },
     appRunner: () => runApp(
       SentryScreenshotWidget(
-        child: TeslaAndroid(),
+        child: SentryUserInteractionWidget(
+          child: TeslaAndroid(),
+        ),
       ),
     ),
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,6 @@ Future<void> main() async {
 }
 
 Future<void> _runMyApp() async {
-  // Sentry already initialized WidgetsFlutterBinding.ensureInitialized();
   await configureTADependencies();
 
   runApp(


### PR DESCRIPTION
* Enables the user [interaction feature](https://docs.sentry.io/platforms/flutter/performance/instrumentation/automatic-instrumentation/#user-interaction-instrumentation) (For breadcrumbs).

When calling `Sentry.captureException(...);` either you `await` the call or pass the `stackTrace` field.
Otherwise, Sentry relies on `StackTrace.current` and if you don't `await` or pass the `stackTrace`, it might be not that useful.

If you call `WidgetsFlutterBinding.ensureInitialized();` out of the Zone that runs Sentry, Async and Future exceptions won't be caught automatically by the SDK.
Flutter solved this by introducing https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onError.html but it's not available for the Web.