### PR TITLE
moving this to the global scope so the DOM isn't read every call

### DIFF
--- a/web/h264.js
+++ b/web/h264.js
@@ -1,5 +1,6 @@
 var img = document.getElementById("image");
 var canvas = document.getElementById("canvas");
+var statsElement = document.getElementById('stats');
 img.style.display = "none";
 canvas.style.display = "block";
 
@@ -9,7 +10,7 @@ canvas.height = window.innerHeight;
 const worker = new Worker('h264_worker.js');
 const offscreenCanvas = canvas.transferControlToOffscreen();
 
-worker.postMessage({canvas: offscreenCanvas, displayWidth: displayWidth, displayHeight: displayHeight, windowWidth: window.innerWidth, windowHeight: window.innerHeight}, [offscreenCanvas]);
+worker.postMessage({ canvas: offscreenCanvas, displayWidth: displayWidth, displayHeight: displayHeight, windowWidth: window.innerWidth, windowHeight: window.innerHeight }, [offscreenCanvas]);
 
 worker.onmessage = function (event) {
   const stats = event.data;
@@ -17,12 +18,12 @@ worker.onmessage = function (event) {
 };
 
 function updateStatsDisplay(stats) {
-  const statsElement = document.getElementById('stats');
+
   if (statsElement) {
     statsElement.textContent = 'Skipped Frames: ' + stats.skippedFrames + ' Buffer size: ' + stats.bufferLength;
   }
 }
 
 function drawDisplayFrame(arrayBuffer) {
-    worker.postMessage({h264Data: arrayBuffer});
+  worker.postMessage({ h264Data: arrayBuffer });
 }


### PR DESCRIPTION
It's probably not a noticeable speed difference, but because the var was defined in the scope of updateStatsDisplay(stats). The DOM would have been checked on each stat update to see if it exists. If I followed the code correctly, that would happen on every frame.