### PR TITLE
Remove audio delay (1s) when reconnecting websockets.

### DIFF
--- a/web/audioplayback.js
+++ b/web/audioplayback.js
@@ -60,7 +60,7 @@ function createAudioSocket(url) {
     } else {
         console.log("Audio: Enabled");
 
-        audioSocket = new ReconnectingWebSocket(url, null, { binaryType: 'arraybuffer' });
+        audioSocket = new ReconnectingWebSocket(url, null, { binaryType: 'arraybuffer', reconnectInterval: 0 });
 
         audioSocket.onopen = () => {
             log("Audio: Websocket connection established")


### PR DESCRIPTION
https://github.com/tesla-android/issue-tracker/issues/337

I had previously raised an issue, but after applying this patch, the 1 second audio silence does not occur.